### PR TITLE
Refactor for Dashboard API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tutum
 
+[![wercker status](https://app.wercker.com/status/06ef9657d0cf0423d2c6123b964e39f3/s "wercker status")](https://app.wercker.com/project/bykey/06ef9657d0cf0423d2c6123b964e39f3)
+
 tutum is a wrapper around Tutum's API for Node.js.
 
 ## Installation
@@ -11,112 +13,47 @@ tutum is a wrapper around Tutum's API for Node.js.
 The first thing you need to do is to integrate tutum in your application.
 
 ```javascript
-var tutum = require('tutum');
+var Tutum = require('tutum');
 ```
 
-Then you need to authenticate using your username and your API key. See the [Tutum documentation](http://docs.tutum.co/) if you don't know how to get that key.
+Then you need create a new instance by passing using your username and your API
+key.  See the [Tutum documentation](https://docs.tutum.co/v2/api) if you don't know how
+to get that key.
 
 ```javascript
-tutum.authenticate({ username: 'foo', apiKey: 'bar' }, function (err, cloud) {
-  // ...
+
+var client = new Tutum({
+  username: 'foo',
+  apiKey: 'bar'
 });
 ```
 
-The `cloud` object that is returned then gives you access to all of Tutum's functionality.
-
-### Applications
-
-#### Getting a list of applications
-
-To get a list of applications, call the `getApplications` function.
+You now can preform GET, POST, PATCH and DELETE requests using the helpers.
 
 ```javascript
-cloud.getApplications(function (err, applications, metadata) {
-  // ...
-});
+client.get(path, params, callback);
+client.post(path, params, callback);
+client.patch(path, params, callback);
+client.delete(path, params, callback);
 ```
 
-Optionally, you can provide query criteria.
+Refer to the [documentation](https://docs.tutum.co/v2/api/) to find the
+appropriate method and path for your request.
 
 ```javascript
-cloud.getApplications({ limit: 10 }, function (err, applications, metadata) {
-  // ...
+// [List all successful actions](https://docs.tutum.co/v2/api/#list-all-actions)
+client.get('/action', {state: 'Success'} function(error, response){
+  if (error) throw error;
+  console.log(response);
 });
-```
 
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#list-all-applications).
-
-#### Getting application details
-
-To get details for an applications, call the `getApplicationDetails` function.
-
-```javascript
-cloud.getApplicationDetails(applicationId, function (err, details) {
-  // ...
+// [Start a container](https://docs.tutum.co/v2/api/#start-a-container)
+client.post('/container/[UUID]/start', function(error, response){
+  if (error) throw error;
+  console.log(response);
 });
+
 ```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#get-application-details).
-
-#### Creating a new application
-
-To create a new application, call the `createApplication` function.
-
-```javascript
-cloud.createApplication({ image: 'tutum/hello-world' }, function (err, details) {
-  // ...
-});
-```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#create-and-launch-a-new-application).
-
-#### Updating an application
-
-To update an application, call the `updateApplication` function.
-
-```javascript
-cloud.updateApplication(applicationId, { target_num_containers: 2 }, function (err, details) {
-  // ...
-});
-```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#update-an-application).
-
-#### Starting an application
-
-To start an application, call the `startApplication` function.
-
-```javascript
-cloud.startApplication(applicationId, function (err, details) {
-  // ...
-});
-```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#stop-an-application).
-
-#### Stopping an application
-
-To stop an application, call the `stopApplication` function.
-
-```javascript
-cloud.stopApplication(applicationId, function (err, details) {
-  // ...
-});
-```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#stop-an-application).
-
-#### Terminating an application
-
-To terminate an application, call the `terminateApplication` function.
-
-```javascript
-cloud.terminateApplication(applicationId, function (err, details) {
-  // ...
-});
-```
-
-For details see the [Tutum API documentation](http://docs.tutum.co/reference/api/#terminate-an-application).
 
 ## Running the tests
 
@@ -124,16 +61,6 @@ This module can be built using [Grunt](http://gruntjs.com/). Besides running the
 
     $ grunt
 
-Please note that for the tests to work you need a Tutum account. Add a file with the name `credentials.json` to the `test` directory and deposit your credentials in the following format:
-
-```javascript
-{
-  "username": "foo",
-  "apiKey": "bar"
-}
-```
-
-The file `.gitignore` contains a rule that excludes this file from being committed.
 
 ## License
 

--- a/examples/service.js
+++ b/examples/service.js
@@ -1,0 +1,16 @@
+'use strict';
+
+var Tutum = require('../lib/tutum');
+
+var client = new Tutum({
+  username: process.env.TUTUM_USERNAME || '',
+  apiKey: process.env.TUTUM_APIKEY || ''
+});
+
+var params = {image: 'tutum/hello-world'};
+client.post('service', params, function(error, response){
+  if (error) {
+    throw error;
+  }
+  console.log(response);
+});

--- a/lib/tutum.js
+++ b/lib/tutum.js
@@ -1,115 +1,64 @@
 'use strict';
 
 var querystring = require('querystring'),
-    util = require('util');
+    extend = require('util')._extend,
+    request = require('superagent');
 
-var request = require('superagent');
-
-var tutum = {};
-
-tutum.authenticate = function (credentials, callback) {
-  if (!credentials) { throw new Error('Credentials are missing.'); }
-  if (!credentials.username) { throw new Error('Username is missing.'); }
-  if (!credentials.apiKey) { throw new Error('API key is missing.'); }
-  if (!callback) { throw new Error('Callback is missing.'); }
-
-  var cloud = {};
-
-  var sendRequest = function (options, callback) {
-    var method = (options.method || 'GET').toLowerCase();
-    if (method === 'delete') { method = 'del'; }
-
-    request
-      [method](util.format('https://app.tutum.co%s?%s', options.path, querystring.stringify(options.query)))
-      .send(options.data || {})
-      .set('Accept', 'application/json')
-      .set('Authorization', util.format('ApiKey %s:%s', credentials.username, credentials.apiKey))
-      .set('Content-Type', 'application/json')
-      .end(function (err, res) {
-        if (err) { return callback(err); }
-        if (res.error) { return callback(res.error); }
-        callback(null, res.body);
-      });
-
+var Tutum = function(config){
+  var defaults = {
+    baseEndpoint: 'https://dashboard.tutum.co/api/v1',
+    username: '',
+    apiKey: ''
   };
 
-  cloud.getApplicationDetails = function (applicationId, callback) {
-    if (!applicationId) { throw new Error('Application id is missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
+  this.config = extend(defaults, config);
+  this.config.authorization = this.config.username + ':' + this.config.apiKey;
 
-    sendRequest({ path: util.format('/api/v1/application/%s/', applicationId) }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
+  this.request = function(method, path, params, callback) {
 
-  cloud.getApplications = function (options, callback) {
-    if (!callback) {
-      callback = options;
-      options = {};
+    var body = {};
+
+    var url = this.config.baseEndpoint;
+    
+    // Add leading and trailing slashes to the path if they do not exist
+    url += path.replace(/^\/?/, '/').replace(/\/?$/, '/');
+
+    callback = (typeof params === 'function') ? params : callback;
+
+    method = method.toLowerCase();
+    method = (method === 'delete') ? 'del' : method;
+
+    if (method === ('post' || 'patch')) {
+      body = params;
+    }
+    else {
+      url += '?' + querystring.stringify(params);
     }
 
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ path: '/api/v1/application/', query: options }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res.objects, res.meta);
-    });
+    request
+      [method](url)
+      .send(body)
+      .set('Accept', 'application/json')
+      .set('Authorization', 'ApiKey ' + this.config.authorization)
+      .set('Content-Type', 'application/json')
+      .end(function (err, res) {
+        if (err) {
+          return callback(err);
+        }
+        if (res.error) {
+          return callback(res.error);
+        }
+        callback(null, res.body);
+      });
   };
 
-  cloud.createApplication = function (options, callback) {
-    if (!options) { throw new Error('Options are missing.'); }
-    if (!options.image) { throw new Error('Image is missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ method: 'POST', path: '/api/v1/application/', data: options }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
-
-  cloud.updateApplication = function (applicationId, options, callback) {
-    if (!applicationId) { throw new Error('Application id is missing.'); }
-    if (!options) { throw new Error('Options are missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ method: 'PATCH', path: util.format('/api/v1/application/%s/', applicationId), data: options }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
-
-  cloud.startApplication = function (applicationId, callback) {
-    if (!applicationId) { throw new Error('Application id is missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ method: 'POST', path: util.format('/api/v1/application/%s/start/', applicationId) }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
-
-  cloud.stopApplication = function (applicationId, callback) {
-    if (!applicationId) { throw new Error('Application id is missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ method: 'POST', path: util.format('/api/v1/application/%s/stop/', applicationId) }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
-
-  cloud.terminateApplication = function (applicationId, callback) {
-    if (!applicationId) { throw new Error('Application id is missing.'); }
-    if (!callback) { throw new Error('Callback is missing.'); }
-
-    sendRequest({ method: 'DELETE', path: util.format('/api/v1/application/%s/', applicationId) }, function (err, res) {
-      if (err) { return callback(err); }
-      return callback(null, res);
-    });
-  };
-
-  callback(null, cloud);
 };
 
-module.exports = tutum;
+// Helper instance methods for get, post, patch and delete
+['get', 'post', 'patch', 'delete'].forEach(function(method){
+  Tutum.prototype[method] = function(path, params, callback) {
+    this.request(method, path, params, callback);
+  };
+});
+
+module.exports = Tutum;

--- a/test/tutumTests.js
+++ b/test/tutumTests.js
@@ -1,457 +1,80 @@
 'use strict';
 
 var assert = require('node-assertthat');
+var Tutum = require('../lib/tutum');
 
-var tutum = require('../lib/tutum');
+suite('Tutum', function(){
 
-var credentials = require('./credentials.json');
+  suite('constructor', function(){
 
-var timeoutBetweenCalls = 40 * 1000,
-    timeoutForTests = 4 * 60 * 1000;
+    test('is a function', function(){
+      assert.that(Tutum, is.ofType('function'));
+    });
 
-credentials.fake = {
-  username: 'foo',
-  apiKey: 'bar'
-};
+    test('instance is object', function(){
+      assert.that(new Tutum(), is.ofType('object'));
+    });
 
-suite('tutum', function () {
-  this.timeout(timeoutForTests);
+    test('required configuration is present', function(){
+      var config = {
+        foo: 'bar'
+      };
+      var instance = new Tutum(config);
 
-  test('is an object.', function () {
-    assert.that(tutum, is.ofType('object'));
+      assert.that(instance.config.baseEndpoint, is.ofType('string'));
+      assert.that(instance.config.username, is.ofType('string'));
+      assert.that(instance.config.apiKey, is.ofType('string'));
+    });
+
+    test('configuration is extended', function(){
+      var config = {
+        baseEndpoint: 'http://example.com',
+        username: 'foo',
+        apiKey: 'bar'
+      };
+      var instance = new Tutum(config);
+
+      assert.that(instance.config.baseEndpoint, is.equalTo(config.baseEndpoint));
+      assert.that(instance.config.username, is.equalTo(config.username));
+      assert.that(instance.config.apiKey, is.equalTo(config.apiKey));
+    });
+
+    test('authorization string is built', function(){
+      var config = {
+        username: 'foo',
+        apiKey: 'bar'
+      };
+      var instance = new Tutum(config);
+
+      assert.that(
+        instance.config.authorization,
+        is.equalTo(config.username + ':' + config.apiKey)
+      );
+    });
+
   });
 
-  suite('authenticate', function () {
-    test('is a function.', function () {
-      assert.that(tutum.authenticate, is.ofType('function'));
+  suite('instance methods', function(){
+    var instance = new Tutum();
+    test('instance.request is a function', function(){
+      assert.that(instance.request, is.ofType('function'));
     });
 
-    test('throws an error if the credentials are missing.', function () {
-      assert.that(function () {
-        tutum.authenticate();
-      }, is.throwing('Credentials are missing.'));
+    test('instance.get is a function', function(){
+      assert.that(instance.request, is.ofType('function'));
     });
 
-    test('throws an error if the credentials do not contain the username.', function () {
-      assert.that(function () {
-        tutum.authenticate({
-          apiKey: credentials.apiKey
-        });
-      }, is.throwing('Username is missing.'));
+    test('instance.post is a function', function(){
+      assert.that(instance.request, is.ofType('function'));
     });
 
-    test('throws an error if the credentials do not contain the API key.', function () {
-      assert.that(function () {
-        tutum.authenticate({
-          username: credentials.username
-        });
-      }, is.throwing('API key is missing.'));
+    test('instance.patch is a function', function(){
+      assert.that(instance.request, is.ofType('function'));
     });
 
-    test('throws an error if the callback is missing.', function () {
-      assert.that(function () {
-        tutum.authenticate(credentials);
-      }, is.throwing('Callback is missing.'));
-    });
-
-    test('returns a reference to the cloud.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(err, is.null());
-        assert.that(cloud, is.ofType('object'));
-        done();
-      });
-    });
-  });
-
-  suite('getApplications', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.getApplications, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error is the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.getApplications();
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.getApplications(function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns a list of applications.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.getApplications(function (err, applications, metadata) {
-          assert.that(err, is.null());
-          assert.that(applications, is.ofType('object'));
-          assert.that(metadata, is.ofType('object'));
-          done();
-        });
-      });
-    });
-
-    test('respects query criteria.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.getApplications({ limit: 10 }, function (err, applications, metadata) {
-          assert.that(err, is.null());
-          assert.that(applications, is.ofType('object'));
-          assert.that(metadata, is.ofType('object'));
-          done();
-        });
-      });
+    test('instance.delete is a function', function(){
+      assert.that(instance.request, is.ofType('function'));
     });
   });
 
-  suite('getApplicationDetails', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.getApplicationDetails, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the application id is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.getApplicationDetails();
-        }, is.throwing('Application id is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.getApplicationDetails('foo');
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.getApplicationDetails('foo', function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns an error if the application id does not exist.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.getApplicationDetails('foo', function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the application details.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, detailsCreated) {
-          setTimeout(function () {
-            cloud.getApplicationDetails(detailsCreated.uuid, function (err, details) {
-              assert.that(err, is.null());
-              assert.that(details, is.ofType('object'));
-              setTimeout(function () {
-                cloud.terminateApplication(detailsCreated.uuid, done);
-              }, timeoutBetweenCalls);
-            });
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
-
-  suite('createApplication', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.createApplication, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the options are missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.createApplication();
-        }, is.throwing('Options are missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the image is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.createApplication({});
-        }, is.throwing('Image is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.createApplication({ image: 'tutum/hello-world' });
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the details of the created application.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, details) {
-          assert.that(err, is.null());
-          assert.that(details, is.ofType('object'));
-          setTimeout(function () {
-            cloud.terminateApplication(details.uuid, done);
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
-
-  suite('updateApplication', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.updateApplication, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the application id is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.updateApplication();
-        }, is.throwing('Application id is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the options are missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.updateApplication('foo');
-        }, is.throwing('Options are missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          /*jshint -W106 */
-          cloud.updateApplication('foo', { target_num_containers: 2 });
-          /*jshint +W106 */
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        /*jshint -W106 */
-        cloud.updateApplication('foo', { target_num_containers: 2 }, function (err) {
-          /*jshint +W106 */
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the details of the updated application.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, detailsCreated) {
-          setTimeout(function () {
-            /*jshint -W106 */
-            cloud.updateApplication(detailsCreated.uuid, { target_num_containers: 2 }, function (err, detailsUpdated) {
-              /*jshint +W106 */
-              assert.that(err, is.null());
-              assert.that(detailsUpdated, is.ofType('object'));
-              setTimeout(function () {
-                cloud.terminateApplication(detailsCreated.uuid, done);
-              }, timeoutBetweenCalls);
-            });
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
-
-  suite('startApplication', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.startApplication, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the application id is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.startApplication();
-        }, is.throwing('Application id is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.startApplication('foo');
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.startApplication('foo', function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the details of the stopped application.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, detailsCreated) {
-          setTimeout(function () {
-            cloud.stopApplication(detailsCreated.uuid, function () {
-              setTimeout(function () {
-                cloud.startApplication(detailsCreated.uuid, function (err, detailsStarted) {
-                  assert.that(err, is.null());
-                  assert.that(detailsStarted, is.ofType('object'));
-                  setTimeout(function () {
-                    cloud.terminateApplication(detailsCreated.uuid, done);
-                  }, timeoutBetweenCalls);
-                });
-              }, timeoutBetweenCalls);
-            });
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
-
-  suite('stopApplication', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.stopApplication, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the application id is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.stopApplication();
-        }, is.throwing('Application id is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.stopApplication('foo');
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.stopApplication('foo', function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the details of the stopped application.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, detailsCreated) {
-          setTimeout(function () {
-            cloud.stopApplication(detailsCreated.uuid, function (err, detailsStopped) {
-              assert.that(err, is.null());
-              assert.that(detailsStopped, is.ofType('object'));
-              setTimeout(function () {
-                cloud.terminateApplication(detailsCreated.uuid, done);
-              }, timeoutBetweenCalls);
-            });
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
-
-  suite('terminateApplication', function () {
-    test('is a function.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(cloud.terminateApplication, is.ofType('function'));
-        done();
-      });
-    });
-
-    test('throws an error if the application id is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.terminateApplication();
-        }, is.throwing('Application id is missing.'));
-        done();
-      });
-    });
-
-    test('throws an error if the callback is missing.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        assert.that(function () {
-          cloud.terminateApplication('foo');
-        }, is.throwing('Callback is missing.'));
-        done();
-      });
-    });
-
-    test('returns an error if the credentials are wrong.', function (done) {
-      tutum.authenticate(credentials.fake, function (err, cloud) {
-        cloud.terminateApplication('foo', function (err) {
-          assert.that(err, is.not.null());
-          done();
-        });
-      });
-    });
-
-    test('returns the details of the terminated application.', function (done) {
-      tutum.authenticate(credentials, function (err, cloud) {
-        cloud.createApplication({ image: 'tutum/hello-world' }, function (err, detailsCreated) {
-          setTimeout(function () {
-            cloud.terminateApplication(detailsCreated.uuid, function (err, detailsTerminated) {
-              assert.that(err, is.null());
-              assert.that(detailsTerminated, is.ofType('object'));
-              done();
-            });
-          }, timeoutBetweenCalls);
-        });
-      });
-    });
-  });
 });


### PR DESCRIPTION
#### What's this PR do?

* Introduces a constructor method that takes and stores a configuration parameter.  Instances can make authenticated requests without needing to be wrapped within the authenticate method.
* Removed deprecated resource endpoint helper methods and introduce GET, POST, PATCH and DELETE helpers.
* Adds an example of how to deploy a new service.
* Removes the authentication requirement from the test suite.

#### Any background context you want to provide?

**Why the refactor?**

In September Tutum announced a new version of the API.  The previous endpoints supported by this package have since been deprecated.  In order to reduce the need to make future changes to this library as the Tutum API matures, this patch proposes that the endpoint specific helper functions be removed.  Instead, a set of HTTP helper methods are provided, allowing the user to build not only all of the current endpoints, but future endpoints as well.

So, something like:
````
cloud.startApplication(applicationId, function (err, details) {});
````

Would become something like: (note there is no longer the concept of an application in the API)

````
client.post('service/' . uuid . '/start', function (err, details) {});
````

You will also notice that the argument level error handling has been removed as well.  In almost all cases, the API will return the appropriate error message and HTTP status code.

**Why remove the authenticated tests?**

I think that this package should be responsible for test coverage across the modules and code that it controls.   

#### What are the relevant tickets?

Fixes #1 
Fixes #2 

#### Screenshots (if appropriate)

#### Checklist:
- [X] Code standard review
- [X] Tests included
- [X] Documentation provided

#### Release Type:
- [X] Major
- [ ] Minor
- [ ] Patch